### PR TITLE
Fix no movement issue #1

### DIFF
--- a/Assets/Scenes/2D Stable Fluids.unity
+++ b/Assets/Scenes/2D Stable Fluids.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.12731704, g: 0.1341472, b: 0.121078566, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -294,9 +294,9 @@ MonoBehaviour:
   _resolution: {x: 800, y: 450}
   _diffusion: 0.0000001
   _initialImage: {fileID: 2800000, guid: 7afc347bf0235411dabb6ce477f95cbe, type: 3}
-  _addVelocity: 4
+  _addVelocity: 6
   _addDensity: 3
-  _addVelocityRadius: 2
+  _addVelocityRadius: 3
   _addDensityRadius: 10
 --- !u!4 &1957439556
 Transform:


### PR DESCRIPTION
Fix #1 on Windows machines by using temporary velocity buffers in the advect stage of the simulation to avoid binding the same velocity buffer to two separate StructuredBuffers in the compute shader.